### PR TITLE
Scal 502 secrets config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,4 @@ gem 'scalarm-database', '>= 0.2', git: 'git://github.com/Scalarm/scalarm-databas
 
 ## for local development - set path to scalarm-core
 # gem 'scalarm-service_core', path: '/home/jliput/Scalarm/scalarm-service_core'
-gem 'scalarm-service_core', '~> 0.2.1', git: 'git://github.com/Scalarm/scalarm-service_core.git'
+gem 'scalarm-service_core', '~> 0.3.3', git: 'git://github.com/Scalarm/scalarm-service_core.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,9 +11,9 @@ GIT
 
 GIT
   remote: git://github.com/Scalarm/scalarm-service_core.git
-  revision: f1451d67ebe818f59dd2800e8ff2bea485e6a2f2
+  revision: 7bc9fa8692464df28ffefcc924857cc386ba35c6
   specs:
-    scalarm-service_core (0.2.1)
+    scalarm-service_core (0.3.3)
       actionpack (~> 4.1)
       activesupport (~> 4.1)
       rest-client (~> 1.8)
@@ -141,6 +141,6 @@ DEPENDENCIES
   rails (= 4.1.1)
   rubyzip (~> 0.9.9)
   scalarm-database (>= 0.2)!
-  scalarm-service_core (~> 0.2.1)!
+  scalarm-service_core (~> 0.3.3)!
   sys-filesystem
   thin

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,13 +7,16 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :null_session
 
-  before_filter :start_monitoring
-  after_filter :stop_monitoring
 
+  if Rails.application.secrets.monitoring
+    before_filter :start_monitoring
+    after_filter :stop_monitoring
+
+    @@probe = MonitoringProbe.new
+  end
   rescue_from Scalarm::ServiceCore::AuthenticationError,
               with: :authentication_failed
 
-  @@probe = MonitoringProbe.new
 
   protected
 

--- a/app/controllers/log_bank_controller.rb
+++ b/app/controllers/log_bank_controller.rb
@@ -206,7 +206,7 @@ class LogBankController < ApplicationController
   private
 
   def load_log_bank
-    @log_bank = MongoLogBank.new(YAML.load_file("#{Rails.root}/config/scalarm.yml"))
+    @log_bank = MongoLogBank.new(Rails.application.secrets.database)
     @experiment_id = params[:experiment_id]
     @simulation_id = params[:simulation_id]
   end

--- a/app/models/information_service.rb
+++ b/app/models/information_service.rb
@@ -1,3 +1,4 @@
+require 'scalarm/service_core'
 require 'scalarm/service_core/information_service'
 
 class InformationService < Scalarm::ServiceCore::InformationService

--- a/app/models/monitoring_probe.rb
+++ b/app/models/monitoring_probe.rb
@@ -8,7 +8,9 @@ class MonitoringProbe
 
   def initialize
     log('Starting')
-    @config = YAML.load_file(File.join(Rails.root, 'config', 'scalarm.yml'))['monitoring']
+    @config = Rails.application.secrets.monitoring
+    raise 'No monitoring configuration' if @config.nil?
+
     @db_name = @config['db_name']
     @db = Scalarm::Database::MongoActiveRecord.get_database(@db_name)
     @interval = @config['interval'].to_i

--- a/config/initializers/02_mongo_active_record.rb
+++ b/config/initializers/02_mongo_active_record.rb
@@ -25,22 +25,29 @@ unless Rails.env.test?
   # by default, try to connect to local mongodb
   # TODO: connect to local mongodb only if list of db_routers is empty
   slog('mongo_active_record', 'Trying to connect to localhost')
-  unless Scalarm::Database::MongoActiveRecord.connection_init('localhost', config['db_name'])
 
+  begin
+    Scalarm::Database::MongoActiveRecord.connection_init('localhost', config['db_name'])
+  rescue Mongo::ConnectionFailure
     slog('mongo_active_record', 'Cannot connect to local mongodb - fetching mongodb adresses from IS')
     information_service = InformationService.instance
     storage_manager_list = information_service.get_list_of('db_routers')
 
     if storage_manager_list.blank?
       slog('init', 'Error: db_routers list from IS is empty - there is no database to connect')
-      raise 'db_routers list from IS is empty'
+
+      # TODO: ugly hack to enable :environment in Rakefile for mongo tasks
+      # raise 'db_routers list from IS is empty'
     else
       slog('init', "Fetched db_routers list: #{storage_manager_list}")
       db_router_url = storage_manager_list.sample
       slog('mongo_active_record', "Connecting to '#{db_router_url}'")
-      Scalarm::Database::MongoActiveRecord.connection_init(db_router_url, config['db_name'])
+      begin
+        Scalarm::Database::MongoActiveRecord.connection_init(db_router_url, config['db_name'])
+      rescue Mongo::ConnectionFailure
+        slog('mongo_active_record', 'Cannot connect to remote mongodb')
+      end
     end
-
   end
 
 end

--- a/config/initializers/02_mongo_active_record.rb
+++ b/config/initializers/02_mongo_active_record.rb
@@ -5,9 +5,8 @@ unless Rails.env.test?
 
   # class initizalization
   # config moved to secrets.yml
-  config = YAML.load_file(File.join(Rails.root, 'config', 'scalarm.yml'))
-  # TODO move config to secrets.yml
-  #config = Rails.application.secrets.database
+  #config = YAML.load_file(File.join(Rails.root, 'config', 'scalarm.yml'))
+  config = Rails.application.secrets.database
 
   if config.nil?
     slog('mongo_active_record', 'No database configuration, using defaults')

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,0 +1,95 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure your secret_key_base is kept private
+# if you're sharing your code publicly.
+
+default: &DEFAULT
+  ## cookies enctyption key - set the same in each ExperimentManager to allow cooperation
+  secret_key_base: "<you need to change this - with $rake secret>"
+
+  ## InformationService - a service locator
+  information_service_url: "localhost:11300"
+  information_service_user: "<set to custom name describing your Scalarm instance>"
+  information_service_pass: "<generate strong password instead of this>"
+  ## uncomment, if you want to communicate through HTTP with Scalarm Information Service
+  # information_service_development: true
+
+  ## Database configuration
+  ## name of MongoDB database, it is scalarm_db by default
+  database:
+    db_name: 'scalarm_db'
+    ## key for symmetric encryption of secret database data - please change it in production installations!
+    ## NOTICE: this key should be set ONLY ONCE BEFORE first run - if you change or lost it, you will be UNABLE to read encrypted data!
+    db_secret_key: "QjqjFK}7|Xw8DDMUP-O$yp"
+
+    ## where log bank should store content
+    mongo_host: 'localhost'
+    mongo_port: 27017
+    binaries_collection_name: 'simulation_files'
+
+    ## MongoDB settings
+    ## host is optional - the service will take local ip address if host is not provided
+    host: localhost
+
+    ## MongoDB instance settings
+    db_instance_port: 30000
+    db_instance_dbpath: ./../../scalarm_db_data
+    db_instance_logpath: ./../../log/scalarm_db.log
+
+    ## MongoDB configsrv settings
+    db_config_port: 28000
+    db_config_dbpath: ./../../scalarm_db_config_data
+    db_config_logpath: ./../../log/scalarm_db_config.log
+
+    ## MongoDB router settings
+    db_router_host: localhost
+    db_router_port: 27017
+    db_router_logpath: ./../../log/scalarm_db_router.log
+
+
+  ## Uncomment, if you want to communicate through HTTP with Scalarm Storage Manager
+  # storage_manager_development: true
+
+  ## Configuration of optional Scalarm LoadBalancer (https://github.com/Scalarm/scalarm_load_balancer)
+  load_balancer:
+    # if you installed and want to use scalarm custom load balancer set to false
+    disable_registration: true
+    # if you use load balancer you need to specify multicast address (to receive load balancer address)
+    #multicast_address: "224.1.2.3:8000"
+    # if you use load balancer on http you need to specify this
+    #development: true
+    # if you want to run and register service in load balancer on other port than default
+    #port: "3000"
+
+  ## Uncomment "anonymous_user" block to create and use default user
+  #anonymous_user:
+  #  login: 'anonymous'
+  #  password: 'anonymous'
+
+  ## Configuration of ExperimentManager machine monitoring, uncomment to enable
+  #monitoring:
+  #  db_name: 'scalarm_monitoring'
+  #  interval: 60
+  #  metrics: 'cpu:memory:storage'
+
+production:
+  ## In production environments some settings should not be stored in configuration file
+  ## for security reasons.
+
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  information_service_url: "<%= ENV["INFORMATION_SERVICE_URL"] %>"
+  information_service_user: "<%= ENV["INFORMATION_SERVICE_LOGIN"] %>"
+  information_service_pass: "<%= ENV["INFORMATION_SERVICE_PASSWORD"] %>"
+
+development:
+  <<: *DEFAULT
+
+test:
+  <<: *DEFAULT

--- a/config/thin.yml.example
+++ b/config/thin.yml.example
@@ -1,0 +1,4 @@
+pid: tmp/pids/thin.pid
+log: log/thin.log
+#socket: /tmp/scalarm_storage_manager.sock
+port: 20001


### PR DESCRIPTION
Konfiguracja przeniesiona do secrets.yml - wymaga to utworzenia klucza database w secrets.yml i skopiowanie tam konfiguracji z scalarm.yml
